### PR TITLE
update: more strong type, README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ There are two main components, `Column` and `Row`.
 | --------- | ----------- | ----------- |
 |reverse| true or false |		|
 |vertical|	'start', 'center', 'end', 'stretch', 'baseline' |	at **rows**, *vertical* and *alignItems* are the same	|
-|horizontal|'start', 'center', 'end', 'spaced', 'space-between', 'around', 'space-around', 'space-evenly'|	at **rows**, *horizontal* and *justifyContent* are the same|
-|justifyContent|'start', 'center', 'end', 'spaced', 'space-between', 'around', 'space-around', 'space-evenly'|	at **rows**, *horizontal* and *justifyContent* are the same|
+|horizontal|'start', 'flex-start', 'center', 'end', 'flex-end', 'spaced', 'space-between', 'around', 'space-around', 'space-evenly'|	at **rows**, *horizontal* and *justifyContent* are the same|
+|justifyContent|'start', 'flex-start', 'center', 'end', 'flex-end', 'spaced', 'space-between', 'around', 'space-around', 'space-evenly'|	at **rows**, *horizontal* and *justifyContent* are the same|
 |alignItems|'start', 'center', 'end', 'stretch', 'baseline' |	at **rows**, *vertical* and *alignItems* are the same	|
 |alignSelf|'start', 'center', 'end', 'stretch', 'baseline' |	other alignment for the cross (vertical) axis	|
-|alignContent|'start', 'center', 'end', 'spaced', 'space-between', 'around', 'space-around', 'stretch'|	other alignment for the cross (vertical) axis	|
+|alignContent|'start', 'flex-start', 'center', 'end', 'flex-end', 'spaced', 'space-between', 'around', 'space-around', 'stretch'|	other alignment for the cross (vertical) axis	|
 |flex|	string|		shorthand for grow, shrink and basis |
 |flexGrow|	number|		flex-grow |
 |flexShrink|	number|		flex-shrink |
@@ -54,11 +54,11 @@ There are two main components, `Column` and `Row`.
 | --------- | ----------- | ----------- |
 |reverse| true or false |		|
 |horizontal|	'start', 'center', 'end', 'stretch', 'baseline' |	at **column**, *horizontal* and *alignItems* are the same	|
-|vertical|'start', 'center', 'end', 'spaced', 'space-between', 'around', 'space-around', 'space-evenly'|	at **column**, *vertical* and *justifyContent* are the same|
+|vertical|'start', 'flex-start', 'center', 'end', 'flex-end', 'spaced', 'space-between', 'around', 'space-around', 'space-evenly'|	at **column**, *vertical* and *justifyContent* are the same|
 |justifyContent|'start', 'flex-start', 'center', 'end', 'flex-end', 'spaced', 'space-between', 'around', 'space-around', 'space-evenly'|	at **column**, *vertical* and *justifyContent* are the same|
 |alignItems|'start', 'center', 'end', 'stretch', 'baseline' |	at **column**, *horizontal* and *alignItems* are the same	|
 |alignSelf|'start', 'center', 'end', 'stretch', 'baseline' |	other alignment for the cross (horizontal) axis	|
-|alignContent|'start', 'center', 'end', 'spaced', 'space-between', 'around', 'space-around', 'stretch'|	other alignment for the cross (horizontal) axis	|
+|alignContent|'start', 'flex-start', 'center', 'end', 'flex-end', 'spaced', 'space-between', 'around', 'space-around', 'stretch'|	other alignment for the cross (horizontal) axis	|
 |flex|	string|		shorthand for grow, shrink and basis |
 |flexGrow|	number|		flex-grow |
 |flexShrink|	number|		flex-shrink |

--- a/README.md
+++ b/README.md
@@ -36,16 +36,16 @@ There are two main components, `Column` and `Row`.
 |justifyContent|'start', 'center', 'end', 'spaced', 'space-between', 'around', 'space-around', 'space-evenly'|	at **rows**, *horizontal* and *justifyContent* are the same|
 |alignItems|'start', 'center', 'end', 'stretch', 'baseline' |	at **rows**, *vertical* and *alignItems* are the same	|
 |alignSelf|'start', 'center', 'end', 'stretch', 'baseline' |	other alignment for the cross (vertical) axis	|
-|alignContent|'start', 'center', 'end', 'spaced', 'space-between', 'around', 'space-around'|	other alignment for the cross (vertical) axis	|
+|alignContent|'start', 'center', 'end', 'spaced', 'space-between', 'around', 'space-around', 'stretch'|	other alignment for the cross (vertical) axis	|
 |flex|	string|		shorthand for grow, shrink and basis |
 |flexGrow|	number|		flex-grow |
-|flexShrink|	string|		flex-shrink |
+|flexShrink|	number|		flex-shrink |
 |flexBasis|	string|		flex-basis |
 |wrap|	true or false|	default: false	|
 |wrapReverse|	true or false|	default: false	|
 |any other property| any | i.e.: `style={{bakcgroundColor: 'red'}}`|
 |breakpoints|array of objects| different styles are applied depending on `window.innerWidth`, see **Breakpoints** section below |
-|element | any html tag, such as: `article`, `section`, etc. | Defines to which html tag the styles will be applied. Default: `div` |
+|element |  'article', 'aside', 'div', 'figure', 'footer', 'header', 'main', 'nav', 'section'  | Defines to which html tag the styles will be applied. Default: `div` |
 |children|	|	**required**	|
 
 
@@ -55,19 +55,19 @@ There are two main components, `Column` and `Row`.
 |reverse| true or false |		|
 |horizontal|	'start', 'center', 'end', 'stretch', 'baseline' |	at **column**, *horizontal* and *alignItems* are the same	|
 |vertical|'start', 'center', 'end', 'spaced', 'space-between', 'around', 'space-around', 'space-evenly'|	at **column**, *vertical* and *justifyContent* are the same|
-|justifyContent|'start', 'center', 'end', 'spaced', 'space-between', 'around', 'space-around', 'space-evenly'|	at **column**, *vertical* and *justifyContent* are the same|
+|justifyContent|'start', 'flex-start', 'center', 'end', 'flex-end', 'spaced', 'space-between', 'around', 'space-around', 'space-evenly'|	at **column**, *vertical* and *justifyContent* are the same|
 |alignItems|'start', 'center', 'end', 'stretch', 'baseline' |	at **column**, *horizontal* and *alignItems* are the same	|
 |alignSelf|'start', 'center', 'end', 'stretch', 'baseline' |	other alignment for the cross (horizontal) axis	|
-|alignContent|'start', 'center', 'end', 'spaced', 'space-between', 'around', 'space-around'|	other alignment for the cross (horizontal) axis	|
+|alignContent|'start', 'center', 'end', 'spaced', 'space-between', 'around', 'space-around', 'stretch'|	other alignment for the cross (horizontal) axis	|
 |flex|	string|		shorthand for grow, shrink and basis |
 |flexGrow|	number|		flex-grow |
-|flexShrink|	string|		flex-shrink |
+|flexShrink|	number|		flex-shrink |
 |flexBasis|	string|		flex-basis |
 |wrap|	true or false|	default: false	|
 |wrapReverse|	true or false|	default: false	|
 |any other property| any | i.e.: `style={{bakcgroundColor: 'red'}}`|
 |breakpoints|array of objects| different styles are applied depending on `window.innerWidth`, see **Breakpoints** section below |
-|element | any html tag, such as: `article`, `section`, etc. | Defines to which html tag the styles will be applied. Default: `div` |
+|element |  'article', 'aside', 'div', 'figure', 'footer', 'header', 'main', 'nav', 'section'  | Defines to which html tag the styles will be applied. Default: `div` |
 |children|	|	**required**	|
 
 Breakpoints

--- a/build/index.d.ts
+++ b/build/index.d.ts
@@ -1,106 +1,107 @@
 /// <reference types="react" />
 
 declare module "simple-flexbox" {
-    class Column extends React.Component<ColumnProps> {}
-    class Row extends React.Component<RowProps> {}
-  
-    interface Breakpoints {
-        [key: number]: string | object;
-    }
-    interface ColumnProps extends React.HTMLAttributes<HTMLDivElement> {
-      className?: string;
-      style?: React.CSSProperties;
-      flexGrow?: number;
-      wrap?: boolean;
-      flex?: string;
-      flexShrink?: number;
-      flexBasis?: string;
-      breakpoints?: Breakpoints;
-      reverse?: boolean;
-      children: any;
-      element?: string;
-      vertical?:
-        | "start"
-        | "center"
-        | "end"
-        | "spaced"
-        | "space-between"
-        | "around"
-        | "space-around"
-        | "space-evenly";
-      horizontal?: "start" | "center" | "end" | "stretch";
-      justifyContent?:
-        | "start"
-        | "flex-start"
-        | "center"
-        | "end"
-        | "flex-end"
-        | "spaced"
-        | "space-between"
-        | "around"
-        | "space-around"
-        | "space-evenly";
-      alignItems?: "start" | "center" | "end" | "stretch" | "baseline";
-      alignSelf?: "start" | "center" | "end" | "stretch" | "baseline";
-      alignContent?:
-        | "start"
-        | "flex-start"
-        | "center"
-        | "end"
-        | "flex-end"
-        | "spaced"
-        | "space-between"
-        | "around"
-        | "space-around"
-        | "stretch";
-    }
-  
-    interface RowProps extends React.HTMLAttributes<HTMLDivElement> {
-      className?: string;
-      style?: React.CSSProperties;
-      wrap?: boolean;
-      reverse?: boolean;
-      flex?: string;
-      flexGrow?: number;
-      flexShrink?: number;
-      flexBasis?: string;
-      breakpoints?: Breakpoints;
-      children: any;
-      element?: string;
-      vertical?: "start" | "center" | "end" | "spaced" | "baseline";
-      horizontal?:
-        | "start"
-        | "center"
-        | "end"
-        | "spaced"
-        | "space-between"
-        | "around"
-        | "space-around"
-        | "space-evenly";
-      justifyContent?:
-        | "start"
-        | "flex-start"
-        | "center"
-        | "end"
-        | "flex-end"
-        | "spaced"
-        | "space-between"
-        | "around"
-        | "space-around"
-        | "space-evenly";
-      alignItems?: "start" | "center" | "end" | "stretch" | "baseline";
-      alignSelf?: "start" | "center" | "end" | "stretch" | "baseline";
-      alignContent?:
-        | "start"
-        | "flex-start"
-        | "center"
-        | "end"
-        | "flex-end"
-        | "spaced"
-        | "space-between"
-        | "around"
-        | "space-around"
-        | "stretch";
-    }
+  class Column extends React.Component<ColumnProps> {}
+  class Row extends React.Component<RowProps> {}
+
+  interface Breakpoints {
+    [key: number]: string | object;
   }
-  
+  interface ColumnProps extends React.HTMLAttributes<React.ReactHTML> {
+    className?: string;
+    style?: React.CSSProperties;
+    flexGrow?: number;
+    wrap?: boolean;
+    wrapReverse?: boolean;
+    flex?: string;
+    flexShrink?: number;
+    flexBasis?: string;
+    breakpoints?: Breakpoints;
+    reverse?: boolean;
+    children: any;
+    element?: "article" | "aside" | "div" | "figure" | "footer" | "header" | "main" | "nav" | "section";
+    vertical?:
+      | "start"
+      | "center"
+      | "end"
+      | "spaced"
+      | "space-between"
+      | "around"
+      | "space-around"
+      | "space-evenly";
+    horizontal?: "start" | "center" | "end" | "stretch" | "baseline";
+    justifyContent?:
+      | "flex-start"
+      | "start"
+      | "center"
+      | "end"
+      | "flex-end"
+      | "spaced"
+      | "space-between"
+      | "around"
+      | "space-around"
+      | "space-evenly";
+    alignItems?: "start" | "center" | "end" | "stretch" | "baseline";
+    alignSelf?: "start" | "center" | "end" | "stretch" | "baseline";
+    alignContent?:
+      | "start"
+      | "flex-start"
+      | "center"
+      | "end"
+      | "flex-end"
+      | "spaced"
+      | "space-between"
+      | "around"
+      | "space-around"
+      | "stretch";
+  }
+
+  interface RowProps extends React.HTMLAttributes<React.ReactHTML> {
+    className?: string;
+    style?: React.CSSProperties;
+    wrap?: boolean;
+    wrapReverse?: boolean;
+    reverse?: boolean;
+    flex?: string;
+    flexGrow?: number;
+    flexShrink?: number;
+    flexBasis?: string;
+    breakpoints?: Breakpoints;
+    children: any;
+    element?: "article" | "aside" | "div" | "figure" | "footer" | "header" | "main" | "nav" | "section";
+    vertical?: "start" | "center" | "end" | "stretch" | "baseline";
+    horizontal?:
+      | "start"
+      | "center"
+      | "end"
+      | "spaced"
+      | "space-between"
+      | "around"
+      | "space-around"
+      | "space-evenly";
+    justifyContent?:
+      | "flex-start"
+      | "start"
+      | "center"
+      | "end"
+      | "flex-end"
+      | "spaced"
+      | "space-between"
+      | "around"
+      | "space-around"
+      | "space-evenly";
+    alignItems?: "start" | "center" | "end" | "stretch" | "baseline";
+    alignSelf?: "start" | "center" | "end" | "stretch" | "baseline";
+    alignContent?:
+      | "flex-start"
+      | "start"
+      | "center"
+      | "end"
+      | "flex-end"
+      | "spaced"
+      | "space-between"
+      | "around"
+      | "space-around"
+      | "stretch"
+  }
+}

--- a/build/index.d.ts
+++ b/build/index.d.ts
@@ -1,107 +1,111 @@
 /// <reference types="react" />
 
 declare module "simple-flexbox" {
-  class Column extends React.Component<ColumnProps> {}
-  class Row extends React.Component<RowProps> {}
+    class Column extends React.Component<ColumnProps> { }
+    class Row extends React.Component<RowProps> { }
 
-  interface Breakpoints {
-    [key: number]: string | object;
-  }
-  interface ColumnProps extends React.HTMLAttributes<React.ReactHTML> {
-    className?: string;
-    style?: React.CSSProperties;
-    flexGrow?: number;
-    wrap?: boolean;
-    wrapReverse?: boolean;
-    flex?: string;
-    flexShrink?: number;
-    flexBasis?: string;
-    breakpoints?: Breakpoints;
-    reverse?: boolean;
-    children: any;
-    element?: "article" | "aside" | "div" | "figure" | "footer" | "header" | "main" | "nav" | "section";
-    vertical?:
-      | "start"
-      | "center"
-      | "end"
-      | "spaced"
-      | "space-between"
-      | "around"
-      | "space-around"
-      | "space-evenly";
-    horizontal?: "start" | "center" | "end" | "stretch" | "baseline";
-    justifyContent?:
-      | "flex-start"
-      | "start"
-      | "center"
-      | "end"
-      | "flex-end"
-      | "spaced"
-      | "space-between"
-      | "around"
-      | "space-around"
-      | "space-evenly";
-    alignItems?: "start" | "center" | "end" | "stretch" | "baseline";
-    alignSelf?: "start" | "center" | "end" | "stretch" | "baseline";
-    alignContent?:
-      | "start"
-      | "flex-start"
-      | "center"
-      | "end"
-      | "flex-end"
-      | "spaced"
-      | "space-between"
-      | "around"
-      | "space-around"
-      | "stretch";
-  }
+    interface Breakpoints {
+        [key: number]: string | object;
+    }
+    interface ColumnProps extends React.HTMLAttributes<React.ReactHTML> {
+        className?: string;
+        style?: React.CSSProperties;
+        flexGrow?: number;
+        wrap?: boolean;
+        wrapReverse?: boolean;
+        flex?: string;
+        flexShrink?: number;
+        flexBasis?: string;
+        breakpoints?: Breakpoints;
+        reverse?: boolean;
+        children: any;
+        element?: "article" | "aside" | "div" | "figure" | "footer" | "header" | "main" | "nav" | "section";
+        vertical?:
+        | "flex-start"
+        | "start"
+        | "center"
+        | "end"
+        | "flex-end"
+        | "spaced"
+        | "space-between"
+        | "around"
+        | "space-around"
+        | "space-evenly";
+        horizontal?: "start" | "center" | "end" | "stretch" | "baseline";
+        justifyContent?:
+        | "flex-start"
+        | "start"
+        | "center"
+        | "end"
+        | "flex-end"
+        | "spaced"
+        | "space-between"
+        | "around"
+        | "space-around"
+        | "space-evenly";
+        alignItems?: "start" | "center" | "end" | "stretch" | "baseline";
+        alignSelf?: "start" | "center" | "end" | "stretch" | "baseline";
+        alignContent?:
+        | "start"
+        | "flex-start"
+        | "center"
+        | "end"
+        | "flex-end"
+        | "spaced"
+        | "space-between"
+        | "around"
+        | "space-around"
+        | "stretch";
+    }
 
-  interface RowProps extends React.HTMLAttributes<React.ReactHTML> {
-    className?: string;
-    style?: React.CSSProperties;
-    wrap?: boolean;
-    wrapReverse?: boolean;
-    reverse?: boolean;
-    flex?: string;
-    flexGrow?: number;
-    flexShrink?: number;
-    flexBasis?: string;
-    breakpoints?: Breakpoints;
-    children: any;
-    element?: "article" | "aside" | "div" | "figure" | "footer" | "header" | "main" | "nav" | "section";
-    vertical?: "start" | "center" | "end" | "stretch" | "baseline";
-    horizontal?:
-      | "start"
-      | "center"
-      | "end"
-      | "spaced"
-      | "space-between"
-      | "around"
-      | "space-around"
-      | "space-evenly";
-    justifyContent?:
-      | "flex-start"
-      | "start"
-      | "center"
-      | "end"
-      | "flex-end"
-      | "spaced"
-      | "space-between"
-      | "around"
-      | "space-around"
-      | "space-evenly";
-    alignItems?: "start" | "center" | "end" | "stretch" | "baseline";
-    alignSelf?: "start" | "center" | "end" | "stretch" | "baseline";
-    alignContent?:
-      | "flex-start"
-      | "start"
-      | "center"
-      | "end"
-      | "flex-end"
-      | "spaced"
-      | "space-between"
-      | "around"
-      | "space-around"
-      | "stretch"
-  }
+    interface RowProps extends React.HTMLAttributes<React.ReactHTML> {
+        className?: string;
+        style?: React.CSSProperties;
+        wrap?: boolean;
+        wrapReverse?: boolean;
+        reverse?: boolean;
+        flex?: string;
+        flexGrow?: number;
+        flexShrink?: number;
+        flexBasis?: string;
+        breakpoints?: Breakpoints;
+        children: any;
+        element?: "article" | "aside" | "div" | "figure" | "footer" | "header" | "main" | "nav" | "section";
+        vertical?: "start" | "center" | "end" | "stretch" | "baseline";
+        horizontal?:
+        | "flex-start"
+        | "start"
+        | "center"
+        | "end"
+        | "flex-end"
+        | "spaced"
+        | "space-between"
+        | "around"
+        | "space-around"
+        | "space-evenly";
+        justifyContent?:
+        | "flex-start"
+        | "start"
+        | "center"
+        | "end"
+        | "flex-end"
+        | "spaced"
+        | "space-between"
+        | "around"
+        | "space-around"
+        | "space-evenly";
+        alignItems?: "start" | "center" | "end" | "stretch" | "baseline";
+        alignSelf?: "start" | "center" | "end" | "stretch" | "baseline";
+        alignContent?:
+        | "flex-start"
+        | "start"
+        | "center"
+        | "end"
+        | "flex-end"
+        | "spaced"
+        | "space-between"
+        | "around"
+        | "space-around"
+        | "stretch"
+    }
 }

--- a/build/index.js
+++ b/build/index.js
@@ -517,13 +517,13 @@ Layout.propTypes = {
     rowReverse: _propTypes2.default.bool,
     columnReverse: _propTypes2.default.bool,
 
-    justifyContent: _propTypes2.default.oneOf(['start', 'flex-start', 'center', 'end', 'flex-end', 'spaced', 'space-between', 'around', 'space-around']),
+    justifyContent: _propTypes2.default.oneOf(['start', 'flex-start', 'center', 'end', 'flex-end', 'spaced', 'space-between', 'around', 'space-around', 'space-evenly']),
 
     alignItems: _propTypes2.default.oneOf(['start', 'center', 'end', 'stretch', 'baseline']),
 
     alignSelf: _propTypes2.default.oneOf(['start', 'center', 'end', 'stretch', 'baseline']),
 
-    alignContent: _propTypes2.default.oneOf(['start', 'flex-start', 'center', 'end', 'flex-end', 'spaced', 'space-between', 'around', 'space-around']),
+    alignContent: _propTypes2.default.oneOf(['start', 'flex-start', 'center', 'end', 'flex-end', 'spaced', 'space-between', 'around', 'space-around', 'stretch']),
 
     wrap: _propTypes2.default.bool,
     wrapReverse: _propTypes2.default.bool,
@@ -538,7 +538,7 @@ Layout.propTypes = {
 
     breakpoints: _propTypes2.default.object,
 
-    element: _propTypes2.default.string,
+    element: _propTypes2.default.oneOf(['article', 'aside', 'div', 'figure', 'footer', 'header', 'main', 'nav', 'section']),
 
     children: _propTypes2.default.node.isRequired
 };
@@ -596,7 +596,7 @@ var Row = exports.Row = function (_React$Component2) {
 Row.propTypes = {
     reverse: _propTypes2.default.bool,
     vertical: _propTypes2.default.oneOf(['start', 'center', 'end', 'stretch', 'baseline']),
-    horizontal: _propTypes2.default.oneOf(['start', 'center', 'end', 'spaced', 'space-between', 'around', 'space-around', 'space-evenly']),
+    horizontal: _propTypes2.default.oneOf(['start', 'flex-start', 'center', 'end', 'flex-end', 'spaced', 'space-between', 'around', 'space-around', 'space-evenly']),
 
     justifyContent: _propTypes2.default.oneOf(['start', 'flex-start', 'center', 'end', 'flex-end', 'spaced', 'space-between', 'around', 'space-around', 'space-evenly']),
     alignItems: _propTypes2.default.oneOf(['start', 'center', 'end', 'stretch', 'baseline']),
@@ -608,6 +608,7 @@ Row.propTypes = {
     flexShrink: _propTypes2.default.number,
     flexBasis: _propTypes2.default.string,
     breakpoints: _propTypes2.default.object,
+    element: _propTypes2.default.oneOf(['article', 'aside', 'div', 'figure', 'footer', 'header', 'main', 'nav', 'section']),
 
     children: _propTypes2.default.node.isRequired
 };
@@ -665,7 +666,7 @@ var Column = exports.Column = function (_React$Component3) {
 Column.propTypes = {
     reverse: _propTypes2.default.bool,
     horizontal: _propTypes2.default.oneOf(['start', 'center', 'end', 'stretch']),
-    vertical: _propTypes2.default.oneOf(['start', 'center', 'end', 'spaced', 'space-between', 'around', 'space-around', 'space-evenly']),
+    vertical: _propTypes2.default.oneOf(['start', 'flex-start', 'center', 'end', 'flex-end', 'spaced', 'space-between', 'around', 'space-around', 'space-evenly']),
 
     justifyContent: _propTypes2.default.oneOf(['start', 'flex-start', 'center', 'end', 'flex-end', 'spaced', 'space-between', 'around', 'space-around', 'space-evenly']),
     alignItems: _propTypes2.default.oneOf(['start', 'center', 'end', 'stretch', 'baseline']),
@@ -677,6 +678,7 @@ Column.propTypes = {
     flexShrink: _propTypes2.default.number,
     flexBasis: _propTypes2.default.string,
     breakpoints: _propTypes2.default.object,
+    element: _propTypes2.default.oneOf(['article', 'aside', 'div', 'figure', 'footer', 'header', 'main', 'nav', 'section']),
 
     children: _propTypes2.default.node.isRequired
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "simple-flexbox",
-  "version": "2.1.0",
-  "description": "A simple way to make layouts with Flexbox",
+  "version": "2.1.1",
+  "description": "A simple way to make responsive layouts using Flexbox in React",
   "main": "build/index.js",
   "author": {
     "name": "Germán Llorente",

--- a/src/index.js
+++ b/src/index.js
@@ -10,13 +10,13 @@ export class Layout extends React.Component {
         rowReverse: PropTypes.bool,
         columnReverse: PropTypes.bool,
 
-        justifyContent: PropTypes.oneOf(['start', 'flex-start', 'center', 'end', 'flex-end', 'spaced', 'space-between', 'around', 'space-around']),
+        justifyContent: PropTypes.oneOf(['start', 'flex-start', 'center', 'end', 'flex-end', 'spaced', 'space-between', 'around', 'space-around', 'space-evenly']),
 
         alignItems: PropTypes.oneOf(['start', 'center', 'end', 'stretch', 'baseline']),
 
         alignSelf: PropTypes.oneOf(['start', 'center', 'end', 'stretch', 'baseline']),
 
-        alignContent: PropTypes.oneOf(['start', 'flex-start', 'center', 'end', 'flex-end', 'spaced', 'space-between', 'around', 'space-around']),
+        alignContent: PropTypes.oneOf(['start', 'flex-start', 'center', 'end', 'flex-end', 'spaced', 'space-between', 'around', 'space-around', 'stretch']),
 
         wrap: PropTypes.bool,
         wrapReverse: PropTypes.bool,
@@ -31,7 +31,7 @@ export class Layout extends React.Component {
 
         breakpoints: PropTypes.object,
 
-        element: PropTypes.string,
+        element: PropTypes.oneOf(['article', 'aside', 'div', 'figure', 'footer', 'header', 'main', 'nav', 'section']),
 
         children: PropTypes.node.isRequired
     };
@@ -183,7 +183,7 @@ export class Row extends React.Component {
     static propTypes = {
         reverse: PropTypes.bool,
         vertical: PropTypes.oneOf(['start', 'center', 'end', 'stretch', 'baseline']),
-        horizontal: PropTypes.oneOf(['start', 'center', 'end', 'spaced', 'space-between', 'around', 'space-around', 'space-evenly']),
+        horizontal: PropTypes.oneOf(['start', 'flex-start', 'center', 'end', 'flex-end', 'spaced', 'space-between', 'around', 'space-around', 'space-evenly']),
 
         justifyContent: PropTypes.oneOf(['start', 'flex-start', 'center', 'end', 'flex-end', 'spaced', 'space-between', 'around', 'space-around', 'space-evenly']),
         alignItems: PropTypes.oneOf(['start', 'center', 'end', 'stretch', 'baseline']),
@@ -195,6 +195,7 @@ export class Row extends React.Component {
         flexShrink: PropTypes.number,
         flexBasis: PropTypes.string,
         breakpoints: PropTypes.object,
+        element: PropTypes.oneOf(['article', 'aside', 'div', 'figure', 'footer', 'header', 'main', 'nav', 'section']),
 
         children: PropTypes.node.isRequired
     };
@@ -229,7 +230,7 @@ export class Column extends React.Component {
     static propTypes = {
         reverse: PropTypes.bool,
         horizontal: PropTypes.oneOf(['start', 'center', 'end', 'stretch']),
-        vertical: PropTypes.oneOf(['start', 'center', 'end', 'spaced', 'space-between', 'around', 'space-around', 'space-evenly']),
+        vertical: PropTypes.oneOf(['start', 'flex-start', 'center', 'end', 'flex-end', 'spaced', 'space-between', 'around', 'space-around', 'space-evenly']),
 
         justifyContent: PropTypes.oneOf(['start', 'flex-start', 'center', 'end', 'flex-end', 'spaced', 'space-between', 'around', 'space-around', 'space-evenly']),
         alignItems: PropTypes.oneOf(['start', 'center', 'end', 'stretch', 'baseline']),
@@ -241,6 +242,7 @@ export class Column extends React.Component {
         flexShrink: PropTypes.number,
         flexBasis: PropTypes.string,
         breakpoints: PropTypes.object,
+        element: PropTypes.oneOf(['article', 'aside', 'div', 'figure', 'footer', 'header', 'main', 'nav', 'section']),
 
         children: PropTypes.node.isRequired
     };

--- a/src/types/test.tsx
+++ b/src/types/test.tsx
@@ -4,36 +4,125 @@ import React from "react";
 import { Row, Column } from "simple-flexbox";
 
 const Test: React.FC<{}> = () => {
-    return (
-        <>
-            <Row
-                horizontal="center"
-                vertical="center"
-                onClick={() => {
-                    console.log("click");
-                }}
-                ref={null}
-                breakpoints={{
-                    850: { flexDirection: 'row', backgroundColor: 'green' },
-                    600: 'row-reverse'
-                }}
-            >
-                <div style={{ width: "100%", height: "100px", backgroundColor: "red" }} />
-            </Row>
-            <Column
-                horizontal="center"
-                vertical="center"
-                onClick={() => {
-                    console.log("click");
-                }}
-                ref={null}
-                breakpoints={{
-                    850: { flexDirection: 'row', backgroundColor: 'green' },
-                    600: 'row-reverse'
-                }}
-            >
-                <div style={{ width: "100%", height: "100px", backgroundColor: "red" }} />
-            </Column>
-        </>
-    );
+  return (
+    <>
+      <Row
+        horizontal={
+          "start" ||
+          "center" ||
+          "end" ||
+          "spaced" ||
+          "space-between" ||
+          "around" ||
+          "space-around" ||
+          "space-evenly"
+        }
+        vertical={"start" || "center" || "end" || "stretch" || "baseline"}
+        onClick={() => {
+          console.log("click");
+        }}
+        ref={null}
+        breakpoints={{
+          850: { flexDirection: "row", backgroundColor: "green" },
+          600: "row-reverse"
+        }}
+        wrap
+        wrapReverse
+        element={
+          "article" || "aside" || "div" || "figure" || "footer" || "header" || "main" || "nav" || "section"
+        }
+        reverse
+        justifyContent={
+          "start" ||
+          "flex-start" ||
+          "center" ||
+          "end" ||
+          "flex-end" ||
+          "spaced" ||
+          "space-between" ||
+          "around" ||
+          "space-around" ||
+          "space-evenly"
+        }
+        alignItems={"start" || "center" || "end" || "stretch" || "baseline"}
+        alignSelf={"start" || "center" || "end" || "stretch" || "baseline"}
+        alignContent={
+          "start" ||
+          "flex-start" ||
+          "center" ||
+          "end" ||
+          "flex-end" ||
+          "spaced" ||
+          "space-between" ||
+          "around" ||
+          "space-around"
+        }
+        flex="0 1 auto"
+        flexGrow={1}
+        flexShrink={1}
+        flexBasis="fill"
+      >
+        <div style={{ width: "100%", height: "100px", backgroundColor: "red" }} />
+      </Row>
+
+      <Column
+        horizontal={"start" || "center" || "end" || "stretch" || "baseline"}
+        vertical={
+          "start" ||
+          "center" ||
+          "end" ||
+          "spaced" ||
+          "space-between" ||
+          "around" ||
+          "space-around" ||
+          "space-evenly"
+        }
+        onClick={() => {
+          console.log("click");
+        }}
+        ref={null}
+        breakpoints={{
+          850: { flexDirection: "row", backgroundColor: "green" },
+          600: "row-reverse"
+        }}
+        wrap
+        wrapReverse
+        element={
+          "article" || "aside" || "div" || "figure" || "footer" || "header" || "main" || "nav" || "section"
+        }
+        reverse
+        justifyContent={
+          "start" ||
+          "flex-start" ||
+          "center" ||
+          "end" ||
+          "flex-end" ||
+          "spaced" ||
+          "space-between" ||
+          "around" ||
+          "space-around" ||
+          "space-evenly"
+        }
+        alignItems={"start" || "center" || "end" || "stretch" || "baseline"}
+        alignSelf={"start" || "center" || "end" || "stretch" || "baseline"}
+        alignContent={
+          "start" ||
+          "flex-start" ||
+          "center" ||
+          "end" ||
+          "flex-end" ||
+          "spaced" ||
+          "space-between" ||
+          "around" ||
+          "space-around"
+        }
+        flex="0 1 auto"
+        flexGrow={1}
+        flexShrink={1}
+        flexBasis="fill"
+      >
+        <div style={{ width: "100%", height: "100px", backgroundColor: "red" }} />
+      </Column>
+    </>
+  );
 };


### PR DESCRIPTION
**Note:**
1. I added ```'stretch'``` into ```alignContent``` in the README.md because it has ```stretch``` property in the code but was not written in README.md.

2. I added ```flex-start', 'flex-end'``` into ```justifyContent``` and ```alignContent``` in the README.md because of the same reason.

3. I changed ```flexShrink```'s type string to number

and etc... please check.