### PR TITLE
moving webpack out of dependencies into devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
         "build": "webpack"
     },
     "dependencies": {
-        "react": "^15.5.4",
-        "webpack": "^2.6.1"
+        "react": "^15.5.4"
     },
     "devDependencies": {
         "@types/react": "^16.8.23",
@@ -29,7 +28,8 @@
         "babel-preset-env": "^1.5.1",
         "babel-preset-es2015": "^6.24.1",
         "babel-preset-react": "^6.24.1",
-        "babel-preset-stage-0": "^6.24.1"
+        "babel-preset-stage-0": "^6.24.1",
+        "webpack": "^2.6.1"
     },
     "bugs": {
         "url": "https://github.com/llorentegerman/simple-flexbox/issues"


### PR DESCRIPTION
webpack doesn't need to be in dev dependencies. This is causing issues in in other react projects trying to use newer versions of React, which require newer versions of webpack. 